### PR TITLE
fix(build): Ensure correct dependencies when building on AppVeyor.

### DIFF
--- a/src/toofz.Data/WalkEachTargetPerProject.targets
+++ b/src/toofz.Data/WalkEachTargetPerProject.targets
@@ -35,6 +35,7 @@
   </Target>
 
   <Target Name="_WalkEachProjectPerFramework"
+          DependsOnTargets="Restore"
           AfterTargets="_WalkEachTargetPerFramework">
     <PropertyGroup>
       <!-- Include the following outputs in the package. -->


### PR DESCRIPTION
This also handles the case where the Restore target is not called even though Visual Studio performs the restore which causes project references to be included.